### PR TITLE
Fix Task Destruction Warning in Discoverer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+# Configure pytest-asyncio to use function scope for event loops
+def pytest_configure(config):
+    config.option.asyncio_mode = "strict"
+    
+    # Set default fixture loop scope to function scope to avoid deprecation warning
+    config.option.asyncio_default_fixture_loop_scope = "function"

--- a/examples/broadcast.py
+++ b/examples/broadcast.py
@@ -3,7 +3,7 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) # import pylecular
 from pylecular.context import Context
 from pylecular.service import Service
-from pylecular.decorators import action, event
+from pylecular.decorators import event
 from pylecular.broker import Broker
     
 class MySyservice(Service):

--- a/examples/ml_service.py
+++ b/examples/ml_service.py
@@ -3,10 +3,9 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) # import pylecular
 from pylecular.context import Context
 from pylecular.service import Service
-from pylecular.decorators import action, event
+from pylecular.decorators import action
 from pylecular.broker import Broker
 from sklearn.linear_model import LinearRegression # require scikit-learn
-import numpy as np
 import numpy as np
 
 class MLService(Service):

--- a/pylecular/broker.py
+++ b/pylecular/broker.py
@@ -45,6 +45,10 @@ class Broker:
 
 
     async def stop(self):
+        # First stop the discoverer to cancel periodic tasks
+        if hasattr(self.discoverer, 'stop'):
+            await self.discoverer.stop()
+        # Then disconnect the transit
         await self.transit.disconnect()
         self.logger.info("Service broker is stopped. Good bye.")
 

--- a/pylecular/broker.py
+++ b/pylecular/broker.py
@@ -1,6 +1,5 @@
 import asyncio
 import signal
-from pylecular.context import Context
 from pylecular.discoverer import Discoverer
 from pylecular.lifecycle import Lifecycle
 from pylecular.node import NodeCatalog

--- a/pylecular/context.py
+++ b/pylecular/context.py
@@ -1,4 +1,3 @@
-import uuid
 
 class Context:
     # TODO: support stream

--- a/pylecular/discoverer.py
+++ b/pylecular/discoverer.py
@@ -5,14 +5,31 @@ class Discoverer:
     def __init__(self, broker):
         self.broker = broker
         self.transit = broker.transit
+        self._tasks = []
         self.__setup_timers__()
 
     def __setup_timers__(self):
         async def periodic_beat():
-            while True:
-                await asyncio.sleep(5)
-                await self.transit.beat()
-        asyncio.create_task(periodic_beat())
+            try:
+                while True:
+                    await asyncio.sleep(5)
+                    await self.transit.beat()
+            except asyncio.CancelledError:
+                # Handle task cancellation gracefully
+                pass
+        
+        task = asyncio.create_task(periodic_beat())
+        self._tasks.append(task)
 
-    
-    # TODO: kill timers
+    async def stop(self):
+        """Cancel all running tasks created by this discoverer."""
+        for task in self._tasks:
+            if not task.done() and not task.cancelled():
+                task.cancel()
+                try:
+                    # Wait for the task to be cancelled with a short timeout
+                    await asyncio.wait_for(asyncio.shield(task), timeout=0.5)
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    # Expected exceptions when cancelling a task
+                    pass
+        self._tasks.clear()

--- a/pylecular/logger.py
+++ b/pylecular/logger.py
@@ -15,7 +15,7 @@ def get_parsed_log_level(log_level):
     return LOG_LEVEL_MAP.get(log_level, logging.INFO)
 
 def moleculer_format_renderer(_, __, event_dict):
-    timestamp = datetime.datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
+    timestamp = datetime.datetime.now(datetime.UTC).isoformat(timespec="milliseconds") + "Z"
     level = event_dict.pop("level", "INFO").upper()
     node = event_dict.pop("node", "<unknown>")
     service = event_dict.pop("service", "<unspecified>")

--- a/pylecular/registry.py
+++ b/pylecular/registry.py
@@ -1,5 +1,4 @@
 
-from pylecular.node import NodeCatalog
 
 
 class Action:

--- a/pylecular/transit.py
+++ b/pylecular/transit.py
@@ -1,10 +1,8 @@
 
 import asyncio
-from pylecular.context import Context
 from pylecular.node import Node
 from pylecular.transporter.base import Transporter
-from pylecular.packet import Packet,Topics
-from pylecular.transporter.base import Transporter
+from pylecular.packet import Packet, Topics
 import psutil
 
 

--- a/pylecular/transporter/nats.py
+++ b/pylecular/transporter/nats.py
@@ -1,5 +1,5 @@
 from .base import Transporter
-from pylecular.packet import Packet, Topics
+from pylecular.packet import Packet
 import nats
 import json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pylecular"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python Moleculer Library"
 authors = [
     { name = "Alvaro Inckot", email = "alvaroinckot@gmail.com" }

--- a/tests/unit/broker_test.py
+++ b/tests/unit/broker_test.py
@@ -1,4 +1,3 @@
-# filepath: /home/edurdias/projects/pylecular/tests/unit/broker_test.py
 import pytest
 import asyncio
 import signal

--- a/tests/unit/broker_test.py
+++ b/tests/unit/broker_test.py
@@ -1,7 +1,4 @@
 import pytest
-import asyncio
-import signal
-import os
 import pytest_asyncio
 from unittest.mock import Mock, AsyncMock
 from pylecular.broker import Broker

--- a/tests/unit/broker_test.py
+++ b/tests/unit/broker_test.py
@@ -1,7 +1,9 @@
+# filepath: /home/edurdias/projects/pylecular/tests/unit/broker_test.py
 import pytest
 import asyncio
 import signal
 import os
+import pytest_asyncio
 from unittest.mock import Mock, AsyncMock
 from pylecular.broker import Broker
 from pylecular.settings import Settings
@@ -53,12 +55,9 @@ def mock_node_catalog():
 def mock_lifecycle():
     return Mock(spec=Lifecycle)
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def broker(mock_transit, mock_registry, mock_node_catalog, mock_lifecycle):
-    # Create and set an event loop for the test
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    
+    """Create a broker instance for testing."""
     settings = Settings(transporter="mock://localhost:4222")
     broker = Broker(
         "test-node",
@@ -68,41 +67,33 @@ async def broker(mock_transit, mock_registry, mock_node_catalog, mock_lifecycle)
         node_catalog=mock_node_catalog,
         lifecycle=mock_lifecycle
     )
-    return broker
+    yield broker
+    # Clean up the broker when the test is done
+    await broker.stop()
 
 @pytest.mark.asyncio
 async def test_broker_initialization(broker):
-    broker_instance = await broker
-    assert broker_instance.id == "test-node"
-    assert broker_instance.version == "0.14.35"
-    assert broker_instance.namespace == "default"
-    assert broker_instance.registry is not None
-    assert broker_instance.transit is not None
+    assert broker.id == "test-node"
+    assert broker.version == "0.14.35"
+    assert broker.namespace == "default"
+    assert broker.registry is not None
+    assert broker.transit is not None
     
 
 @pytest.mark.asyncio
 async def test_broker_start(broker, mock_transit):
-    broker_instance = await broker
-    await broker_instance.start()
+    await broker.start()
 
 
 @pytest.mark.asyncio
 async def test_broker_stop(broker, mock_transit):
-    broker_instance = await broker
-    await broker_instance.stop()
-
-
-@pytest.mark.asyncio
-async def test_broker_stop(broker, mock_transit):
-    broker_instance = await broker
-    await broker_instance.stop()
+    await broker.stop()
     mock_transit.disconnect.assert_called_once()
 
 @pytest.mark.asyncio
 async def test_broker_register_service(broker, mock_registry, mock_node_catalog):
-    broker_instance = await broker
     service = TestService()
-    broker_instance.register(service)
+    broker.register(service)
     mock_registry.register.assert_called_once_with(service)
     mock_node_catalog.ensure_local_node.assert_called_once()
 
@@ -115,10 +106,8 @@ async def test_broker_call_local_action(broker, mock_registry, mock_lifecycle):
     
     context = Mock()
     mock_lifecycle.create_context.return_value = context
-    
-    broker_instance = await broker
 
-    result = await broker_instance.call("test.hello", {"param": "value"})
+    result = await broker.call("test.hello", {"param": "value"})
     
     assert result == "result"
     mock_registry.get_action.assert_called_once_with("test.hello")
@@ -133,10 +122,8 @@ async def test_broker_call_remote_action(broker, mock_registry, mock_transit, mo
     
     context = Mock()
     mock_lifecycle.create_context.return_value = context
-    
-    broker_instance = await broker
 
-    result = await broker_instance.call("remote.action")
+    result = await broker.call("remote.action")
     
     assert result == "remote result"
     mock_transit.request.assert_called_once_with(endpoint, context)
@@ -144,11 +131,9 @@ async def test_broker_call_remote_action(broker, mock_registry, mock_transit, mo
 
 @pytest.mark.asyncio
 async def test_broker_call_nonexistent_action(broker, mock_registry):
-    broker_instance = await broker
-
     mock_registry.get_action.return_value = None
     with pytest.raises(Exception, match="Action nonexistent.action not found."):
-        await broker_instance.call("nonexistent.action")
+        await broker.call("nonexistent.action")
 
 @pytest.mark.asyncio
 async def test_broker_emit_local_event(broker, mock_registry, mock_lifecycle):
@@ -158,10 +143,8 @@ async def test_broker_emit_local_event(broker, mock_registry, mock_lifecycle):
     
     context = Mock()
     mock_lifecycle.create_context.return_value = context
-    
-    broker_instance = await broker
 
-    await broker_instance.emit("test_event", {"param": "value"})
+    await broker.emit("test_event", {"param": "value"})
     
     endpoint.handler.assert_called_once_with(context)
 
@@ -173,10 +156,8 @@ async def test_broker_emit_remote_event(broker, mock_registry, mock_transit, moc
     
     context = Mock()
     mock_lifecycle.create_context.return_value = context
-
-    broker_instance = await broker
     
-    await broker_instance.emit("remote.event")
+    await broker.emit("remote.event")
     
     mock_transit.send_event.assert_called_once_with(endpoint, context)
 
@@ -190,10 +171,8 @@ async def test_broker_broadcast_event(broker, mock_registry, mock_transit, mock_
     
     context = Mock()
     mock_lifecycle.create_context.return_value = context
-    
-    broker_instance = await broker
 
-    await broker_instance.broadcast("test_event")
+    await broker.broadcast("test_event")
     
     local_endpoint.handler.assert_called_once_with(context)
     mock_transit.send_event.assert_called_once_with(remote_endpoint, context)
@@ -201,8 +180,7 @@ async def test_broker_broadcast_event(broker, mock_registry, mock_transit, mock_
 @pytest.mark.asyncio
 async def test_wait_for_services_found_locally(broker, mock_registry):
     mock_registry.get_service.return_value = Mock()
-    broker_instance = await broker
-    await broker_instance.wait_for_services(["test"])
+    await broker.wait_for_services(["test"])
     mock_registry.get_service.assert_called_once_with("test")
 
 @pytest.mark.asyncio
@@ -212,5 +190,4 @@ async def test_wait_for_services_found_remotely(broker, mock_registry, mock_node
     remote_node.id = "remote-node"
     remote_node.services = [{"name": "test"}]
     mock_node_catalog.nodes.values.return_value = [remote_node]
-    broker_instance = await broker
-    await broker_instance.wait_for_services(["test"])
+    await broker.wait_for_services(["test"])

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -1,4 +1,3 @@
-import pytest
 from pylecular.service import Service
 from pylecular.decorators import action, event
 


### PR DESCRIPTION
## Summary:
This PR addresses the warning \"Task was destroyed but it is pending!\" that appears when running tests. The issue was related to the tasks created in the Discoverer's `__setup_timers__` method that weren't being properly cleaned up.
## Changes:
1. **Added task tracking in the Discoverer class**:
   - Added a `_tasks` list to track created async tasks
   - Implemented a `stop()` method to properly cancel and clean up tasks
   - Added proper exception handling for task cancellation
2. **Updated Broker's stop method**:
   - Modified to call the Discoverer's stop method before disconnecting the transit
   - Ensures all periodic tasks are properly cancelled before shutdown
3. **Fixed datetime deprecation warning**:
   - Replaced deprecated `datetime.utcnow()` with `datetime.now(datetime.UTC)`
4. **Enhanced test fixtures**:
   - Updated broker fixture to properly clean up resources by yielding and then stopping
   - Configured pytest-asyncio with proper event loop scopes
## Files modified:
- `pylecular/discoverer.py` - Added task management and clean-up functionality
- `pylecular/broker.py` - Updated stop method to clean up Discoverer tasks
- `pylecular/logger.py` - Fixed datetime deprecation warning
- `tests/unit/broker_test.py` - Improved fixture teardown
- `conftest.py` - Added proper configuration for pytest-asyncio
These changes successfully eliminate the task destruction warnings while ensuring all resources are properly cleaned up during test execution.